### PR TITLE
fixes issue #122

### DIFF
--- a/mappings/InventoryID-LanguageCodes.tsv
+++ b/mappings/InventoryID-LanguageCodes.tsv
@@ -1009,7 +1009,7 @@ InventoryID	LanguageCode	Glottocode	LanguageName	Source
 1008	sna	shon1251	Shona	ph
 1009	bax	bamu1253	Shupamem	ph
 1010	sjr	siar1238	Siar-Lak	ph
-1011	skr	sera1259	Siraiki	ph
+1011	skr	sera1259	Saraiki	ph
 1012	sjw	shaw1249	Shawnee	ph
 1013	skv	nucl1634	Skou	ph
 1014	thm	aheu1239	So	ph


### PR DESCRIPTION
this "fix" deals with issue #122. "Saraiki" seems to be the most-often used canonical language name. Glottolog also uses it and lists some dialects:

http://glottolog.org/resource/languoid/id/sira1262

It's not clear to me from the phono squib which specific dialect this description describes, but since this is our only entry for Saraiki, i will leave the ISO code as [skr] and Glottocode [sear1259]
