### PR TITLE
fixes issue #221

### DIFF
--- a/mappings/InventoryID-LanguageCodes.csv
+++ b/mappings/InventoryID-LanguageCodes.csv
@@ -1015,7 +1015,7 @@
 1014,"thm","aheu1239","So","ph"
 1015,"erk","sout2856","South Efate","ph"
 1016,"spo","spok1245","Spokan","ph"
-1017,"sso","siss1243","Sesotho","ph"
+1017,"sot","sout2807","Sesotho","ph"
 1018,"stw","sata1237","Satawalese","ph"
 1019,"ulw","ulwa1239","Sumo","ph"
 1020,"jup","hupd1244","Hup","ph"


### PR DESCRIPTION
Not much to review: updates an incorrect ISO & Glottocode ID for Sesotho. This wasn't pointed out to me over email by Kevin Tuite, who noticed that Sesotho is not Sissano (the latter spoken in PNG).