### PR TITLE
Palatal as contour

### DIFF
--- a/scripts/add-features.R
+++ b/scripts/add-features.R
@@ -273,6 +273,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             # this is vacuous
             vec$high <- "+"
         }
+        else {
+            warning(paste("GlyphID 031D (uptack) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
+        }
     }
     # downtack
     else if (vec$GlyphID %in% "031E") {
@@ -317,6 +321,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             # assigning +low is vacuous; little else makes sense ???
             vec$low <- "+"
         }
+        else {
+            warning(paste("GlyphID 031E (downtack) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
+        }
     }
     # advanced
     else if (vec$GlyphID %in% "031F") {
@@ -356,6 +364,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             # fronted velar
             vec$front <- "+"
         }
+        else {
+            warning(paste("GlyphID 031F (advanced) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
+        }
     }
     # mid-centralized
     else if (vec$GlyphID %in% "033D") {
@@ -372,6 +384,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             vec$back <- "0"
         } else if (base_glyph %in% "ɔ") {
             vec$back <- "0"
+        }
+        else {
+            warning(paste("GlyphID 033D (mid-centralized) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
         }
     }
     # centralized
@@ -394,6 +410,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             # vacuous; already central in our feat. sys.
             vec$front <- "-"
         }
+        else {
+            warning(paste("GlyphID 0308 (centralized) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
+        }
     }
     # frictionalized
     else if (vec$GlyphID %in% "0353") {
@@ -408,6 +428,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             # would +strident be better?
             vec$delayedRelease <- "+"
         }
+        else {
+            warning(paste("GlyphID 0353 (frictionalized) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
+        }
     }
     # more rounded
     else if (vec$GlyphID %in% "0339") {
@@ -420,6 +444,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
                               "u", "ʊ", "o", "ɔ", "ɒ")) {
             # vacuous: "more round" when already round
             vec$round <- "+"
+        }
+        else {
+            warning(paste("GlyphID 0339 (more-round) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
         }
     }
     # less rounded
@@ -435,6 +463,10 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
                               "u", "ʊ", "o", "ɔ", "ɒ", "w")) {
             # "less round" when round is "ambiguously round"
             vec$round <- "0"
+        }
+        else {
+            warning(paste("GlyphID 031C (less-round) used on base glyph",
+                          base_glyph, "was not handled."), immediate.=TRUE)
         }
     }
     vec

--- a/scripts/add-features.R
+++ b/scripts/add-features.R
@@ -440,6 +440,11 @@ handle_contextual_diacritics <- function(vec, base_glyph) {
             # "more round" when unround means half-round, I guess
             vec$round <- "0"
         }
+        else if (base_glyph %in% c("ɹ", "ɻ")) {
+            # this will be indistinguishable from ɹʷ
+            vec$labial <- "+"
+            vec$round <- "+"
+        }
         else if (base_glyph %in% c("y", "ʏ", "ø", "œ", "ɶ", "ʉ", "ɵ", "ɞ", "ɐ",
                               "u", "ʊ", "o", "ɔ", "ɒ")) {
             # vacuous: "more round" when already round

--- a/scripts/aggregation-helper-functions.R
+++ b/scripts/aggregation-helper-functions.R
@@ -235,8 +235,8 @@ make_typestring <- function(strings, ...) {
         codepts <- get_codepoints(chars)
         codepts[codepts %in% get_codepoints(base_glyphs)] <- "B"
         codepts[codepts %in% get_codepoints(modifiers)] <- "M"
-        codepts[codepts %in% get_codepoints(contour_glyphs)] <- "C"
         codepts[codepts %in% get_codepoints(diacritics)] <- "D"
+        codepts[codepts %in% get_codepoints(contour_glyphs)] <- "C"
         codepts[codepts %in% get_codepoints(tones)] <- "T"
         codepts[codepts %in% get_codepoints(null_phone)] <- "N"
         codepts[codepts %in% get_codepoints(disjunct)] <- "|"
@@ -415,7 +415,7 @@ create_glyph_type_variables <- function(..., envir=.GlobalEnv) {
     ## with their base glyph's feature values, rather than overwriting them.
     ## This grouping is not used for canonical ordering, but for feature vector
     ## construction.
-    contour_glyphs <- c("ⁿ", "ˡ")  # nasal release, lateral release
+    contour_glyphs <- c("ʷ", "ⁿ", "ˡ", "ʲ", "ˠ", "ᶣ", "ˤ")
     ## the null phone *should* only occur in allophones
     null_phone <- "∅"
     ## disjunct is used in UPSID to signify insufficient information to

--- a/scripts/aggregation-helper-functions.R
+++ b/scripts/aggregation-helper-functions.R
@@ -460,7 +460,7 @@ create_glyph_type_variables <- function(..., envir=.GlobalEnv) {
     if ("contour_glyphs" %in% inputs) assign("contour_glyphs", contour_glyphs,
                                              envir)
     if ("base_glyphs" %in% inputs) {
-        assign("base_glyphs", c(vowels, stops, implosives, flaps, nasals, 
+        assign("base_glyphs", c(vowels, stops, implosives, flaps, nasals,
                                 clicks, fricatives, affricates, approximants,
                                 archephonemes), envir)
     }

--- a/scripts/feature-helper-functions.R
+++ b/scripts/feature-helper-functions.R
@@ -15,10 +15,10 @@ get_glyph_type_from_codepoint <- function(codepoint) {
     create_glyph_type_variables(envir=environment())
     glyph_types <- list(base=base_glyphs, tone=tones, modifier=modifiers,
                         diacritic=diacritics, null_phone=null_phone,
-                        disjunct=disjunct)
+                        disjunct=disjunct, contour=contour_glyphs)
     matches <- sapply(glyph_types, function(gtype) glyph %in% gtype)
     n_matches <- sum(as.numeric(matches))
-    if (n_matches > 1) {
+    if (n_matches > 1 && !matches["contour"]) {
         stop("Glyph ", glyph, " (", codepoint, ") matched multiple glyph types: ",
              paste(names(which(matches)), collapse=", "))
     } else if (n_matches == 0) {
@@ -26,6 +26,9 @@ get_glyph_type_from_codepoint <- function(codepoint) {
     }
     glyph_codes <- c(base="B", tone="T", modifier="M", diacritic="D",
                      null_phone="N", disjunct="|")
+    if (matches["contour"]) {
+        return("C")
+    }
     glyph_codes[names(which(matches))]
 }
 


### PR DESCRIPTION
this should hopefully solve some of the "phonemes don't have distinct feature matrices" problems. It makes the modifiers ʷ ⁿ ˡ ʲ ˠ ᶣ and ˤ into contour-feature-forming modifiers (ⁿ and ˡ already were (supposedly), but there was a bug in the code that meant the feature vectors weren't contour anyway).