### PR TITLE
Update phoible-references.bib

### DIFF
--- a/data/phoible-references.bib
+++ b/data/phoible-references.bib
@@ -19502,7 +19502,7 @@
 
 @incollection{1297_abn,
 	Author = {Gardner, Ian},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19516,7 +19516,7 @@
 
 @incollection{1298_any,
 	Author = {Pyne, P. C.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2019-07-29 14:36:50 +0200},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19530,7 +19530,7 @@
 
 @incollection{1299_dgh,
 	Author = {Frick, Esther, J.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19544,7 +19544,7 @@
 
 @incollection{1300_afo,
 	Author = {Mackay, V.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19558,7 +19558,7 @@
 
 @incollection{1301_fuv,
 	Author = {Arnott, D. W.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19572,7 +19572,7 @@
 
 @incollection{1302_acd,
 	Author = {Cleal, Alizon M.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19586,7 +19586,7 @@
 
 @incollection{1303_ayg,
 	Author = {Cleal, Alizon M.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19600,7 +19600,7 @@
 
 @incollection{1304_hbb,
 	Author = {Greive, Jerry A.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19614,7 +19614,7 @@
 
 @incollection{1305_kwl,
 	Author = {Netting, Robert},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19628,7 +19628,7 @@
 
 @incollection{1306_kye,
 	Author = {Cleal, Alizon M.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19642,7 +19642,7 @@
 
 @incollection{1307_bmf,
 	Author = {Pichl, Walter J.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19812,7 +19812,7 @@
 
 @incollection{1320_akp,
 	Author = {Iddah, Robert K.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19826,7 +19826,7 @@
 
 @incollection{1321_bun,
 	Author = {Pichl, Walter J.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19840,7 +19840,7 @@
 
 @incollection{1322_buy,
 	Author = {Pichl, Walter J.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19854,7 +19854,7 @@
 
 @incollection{1323_cpn,
 	Author = {Painter, Colin},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19868,7 +19868,7 @@
 
 @incollection{1324_fap,
 	Author = {Pichl, Walter J.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19882,7 +19882,7 @@
 
 @incollection{1325_gur,
 	Author = {Schaefer, Robert},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19896,7 +19896,7 @@
 
 @incollection{1326_lip,
 	Author = {Allan, Edward J.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19910,7 +19910,7 @@
 
 @incollection{1327_maw,
 	Author = {Osbiston, Rachel},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19937,7 +19937,7 @@
 
 @incollection{1329_pbp,
 	Author = {Ducos, Gisele},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19951,7 +19951,7 @@
 
 @incollection{1330_snw,
 	Author = {Allen, Christine},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -19965,7 +19965,7 @@
 
 @incollection{1331_tiv,
 	Author = {Arnott, D. W.},
-	Booktitle = {West African Langauge Data Sheets},
+	Booktitle = {West African Language Data Sheets},
 	Date-Added = {2014-06-23 21:11:09 +0000},
 	Date-Modified = {2014-06-23 21:11:09 +0000},
 	Editor = {Kropp-Dakubu, M. E.},
@@ -23039,7 +23039,7 @@
 	Filenames = {Edelsten_ndj.pdf},
 	Inventoryid = {1611},
 	Publisher = {Rudiger Koppe},
-	Title = {A grammatical sketch of Chindamba: A Bantu langauge (G52) of Tanzania},
+	Title = {A grammatical sketch of Chindamba: A Bantu language (G52) of Tanzania},
 	Year = {2010}}
 
 @book{1612_Lovestrand_bva,


### PR DESCRIPTION
I spotted a typo in the sections of a book, West African Language Data Sheets.

It says Langauge, instead of Language. I also found it in another reference of a Bantu language. I replace all of them