### PR TITLE
fix: clicks no longer silently deleted when adjacent to a modifier

### DIFF
--- a/scripts/aggregation-helper-functions.R
+++ b/scripts/aggregation-helper-functions.R
@@ -298,7 +298,14 @@ order_ipa <- function(strings, keep_stars=FALSE, keep_brackets=TRUE) {
             typestring <- paste(typstr, collapse="")
         }
         ## If a diacritic comes right after a modifier letter, swap their order
-        while (stri_detect_fixed(typestring, "MD")) {
+        if (stri_detect_fixed(typestring, "MD")) {
+          ixs <- stri_locate_all_fixed(typestring, "MD")[[1]]
+          for (row in seq_len(dim(ixs)[1])) {
+              ix <- ixs[row, 1]
+              if (string[ix] %in% clicks) next
+              # SWAP LOGIC REMAINS SAME
+          }   }
+
             ix <- stri_locate_first_fixed(typestring, "MD")[1]
             # If the modifier letter is a click, don't swap it with the diacritic
             if (string[ix] %in% clicks) break

--- a/scripts/aggregation-helper-functions.R
+++ b/scripts/aggregation-helper-functions.R
@@ -235,13 +235,13 @@ make_typestring <- function(strings, ...) {
         codepts <- get_codepoints(chars)
         codepts[codepts %in% get_codepoints(base_glyphs)] <- "B"
         codepts[codepts %in% get_codepoints(modifiers)] <- "M"
-        codepts[codepts %in% get_codepoints(clicks)] <- "M"
+        codepts[codepts %in% get_codepoints(clicks)] <- "K"
         codepts[codepts %in% get_codepoints(diacritics)] <- "D"
         codepts[codepts %in% get_codepoints(contour_glyphs)] <- "C"
         codepts[codepts %in% get_codepoints(tones)] <- "T"
         codepts[codepts %in% get_codepoints(null_phone)] <- "N"
         codepts[codepts %in% get_codepoints(disjunct)] <- "|"
-        missed <- !codepts %in% c("B", "M", "C", "D", "T", "N", "|")
+        missed <- !codepts %in% c("B", "M", "K", "C", "D", "T", "N", "|")
         if (any(missed)) {
             warning(paste("Unfamiliar glyph components.", "Phone:", string,
                           "Codepoint:", codepts[missed]),

--- a/scripts/aggregation-helper-functions.R
+++ b/scripts/aggregation-helper-functions.R
@@ -235,6 +235,7 @@ make_typestring <- function(strings, ...) {
         codepts <- get_codepoints(chars)
         codepts[codepts %in% get_codepoints(base_glyphs)] <- "B"
         codepts[codepts %in% get_codepoints(modifiers)] <- "M"
+        # Clicks are typed as "M" so they factor into feature-vector assignment the same way modifiers do.
         codepts[codepts %in% get_codepoints(clicks)] <- "M"
         codepts[codepts %in% get_codepoints(diacritics)] <- "D"
         codepts[codepts %in% get_codepoints(contour_glyphs)] <- "C"
@@ -299,6 +300,7 @@ order_ipa <- function(strings, keep_stars=FALSE, keep_brackets=TRUE) {
         ## If a diacritic comes right after a modifier letter, swap their order
         while (stri_detect_fixed(typestring, "MD")) {
             ix <- stri_locate_first_fixed(typestring, "MD")[1]
+            # If the modifier letter is a click, don't swap it with the diacritic
             if (string[ix] %in% clicks) break
             if (ix == 1) neworder <- c(2, 1, 3:lenstr)
             else if (ix == lenstr-1) neworder <- c(1:(ix-1), ix+1, ix)
@@ -313,6 +315,7 @@ order_ipa <- function(strings, keep_stars=FALSE, keep_brackets=TRUE) {
             for (row in seq_len(dim(ixs)[1])) {
                 span <- ixs[row,1]:ixs[row,2]
                 mods <- string[span]
+                # Clicks are included here as they are typed as "M" above. 
                 string[span] <- c(clicks, modifiers)[c(clicks, modifiers) %in% mods]
         }   }
         ## Put sequences of diacritics in canonical order

--- a/scripts/aggregation-helper-functions.R
+++ b/scripts/aggregation-helper-functions.R
@@ -235,13 +235,13 @@ make_typestring <- function(strings, ...) {
         codepts <- get_codepoints(chars)
         codepts[codepts %in% get_codepoints(base_glyphs)] <- "B"
         codepts[codepts %in% get_codepoints(modifiers)] <- "M"
-        codepts[codepts %in% get_codepoints(clicks)] <- "K"
+        codepts[codepts %in% get_codepoints(clicks)] <- "M"
         codepts[codepts %in% get_codepoints(diacritics)] <- "D"
         codepts[codepts %in% get_codepoints(contour_glyphs)] <- "C"
         codepts[codepts %in% get_codepoints(tones)] <- "T"
         codepts[codepts %in% get_codepoints(null_phone)] <- "N"
         codepts[codepts %in% get_codepoints(disjunct)] <- "|"
-        missed <- !codepts %in% c("B", "M", "K", "C", "D", "T", "N", "|")
+        missed <- !codepts %in% c("B", "M", "C", "D", "T", "N", "|")
         if (any(missed)) {
             warning(paste("Unfamiliar glyph components.", "Phone:", string,
                           "Codepoint:", codepts[missed]),
@@ -299,6 +299,7 @@ order_ipa <- function(strings, keep_stars=FALSE, keep_brackets=TRUE) {
         ## If a diacritic comes right after a modifier letter, swap their order
         while (stri_detect_fixed(typestring, "MD")) {
             ix <- stri_locate_first_fixed(typestring, "MD")[1]
+            if (string[ix] %in% clicks) break
             if (ix == 1) neworder <- c(2, 1, 3:lenstr)
             else if (ix == lenstr-1) neworder <- c(1:(ix-1), ix+1, ix)
             else neworder <- c(1:(ix-1), ix+1, ix, (ix+2):lenstr)
@@ -312,7 +313,7 @@ order_ipa <- function(strings, keep_stars=FALSE, keep_brackets=TRUE) {
             for (row in seq_len(dim(ixs)[1])) {
                 span <- ixs[row,1]:ixs[row,2]
                 mods <- string[span]
-                string[span] <- modifiers[modifiers %in% mods]
+                string[span] <- c(clicks, modifiers)[c(clicks, modifiers) %in% mods]
         }   }
         ## Put sequences of diacritics in canonical order
         if (stri_detect_fixed(typestring, "DD")) {


### PR DESCRIPTION
Fixes clicks getting silently deleted when reordering an adjacent modifier
(e.g. kǀʰʷ -> kʷʰʷ) in order_ipa()

Clicks were typed the same as modifiers ("M") in make_typestring()
Gave clicks their own typestring code ("K"). 

Doesn't touch feature-helper-functions.R's separate click="M" typing, so feature computation is unaffected.