### PR TITLE
better pixi env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.66.0
-          activate-environment: true
+          activate-environment: "ci"
       - name: run tests
         working-directory: tests
         run: |

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 authors = ["Daniel McCloy <dan@mccloy.info>"]
 channels = ["conda-forge"]
-name = "dev"
+name = "phoible"
 platforms = ["linux-64"]
 version = "0.1.0"
 
@@ -9,6 +9,15 @@ version = "0.1.0"
 
 [dependencies]
 r = "4.*"
+
+[environments.agg.dependencies]
+r-zoo = ">=1.8_15,<2"
+r-stringi = ">=1.8.7,<2"
+
+[environments.agg.tasks]
+aggregate = { cmd = "Rscript aggregate-raw-data.R", cwd = "scripts" }
+
+[environments.ci.dependencies]
 r-dplyr = "1.1.1.*"
 r-knitr = ">=1.47,<2"
 r-purrr = ">=1.0.2,<2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,14 +10,14 @@ version = "0.1.0"
 [dependencies]
 r = "4.*"
 
-[environments.agg.dependencies]
+[feature.agg.dependencies]
 r-zoo = ">=1.8_15,<2"
 r-stringi = ">=1.8.7,<2"
 
-[environments.agg.tasks]
+[feature.agg.tasks]
 aggregate = { cmd = "Rscript aggregate-raw-data.R", cwd = "scripts" }
 
-[environments.ci.dependencies]
+[feature.ci.dependencies]
 r-dplyr = "1.1.1.*"
 r-knitr = ">=1.47,<2"
 r-purrr = ">=1.0.2,<2"
@@ -25,3 +25,7 @@ r-readr = ">=2.1.5,<3"
 r-stringr = ">=1.5.1,<2"
 r-testthat = ">=3.2.1.1,<4"
 r-withr = ">=3.0.0,<4"
+
+[environments]
+agg = { features = ["agg"] }
+ci = { features = ["ci"] }


### PR DESCRIPTION
separates the pixi environment into
- "default" (just R)
- "agg" (whatever is needed to run the aggregation script)
- "ci" (what is needed to run the tests)

also adds a task, so that `pixi run aggregate` (from anywhere in the repo) will run the aggregation script.