### PR TITLE
Fixed wrong otomi variety in mappings

### DIFF
--- a/mappings/InventoryID-LanguageCodes.csv
+++ b/mappings/InventoryID-LanguageCodes.csv
@@ -95,7 +95,7 @@ InventoryID,Glottocode,ISO6393
 94,luis1253,lui
 95,hopi1249,hop
 96,toho1245,ood
-97,mezq1235,ote
+97,tena1241,otn
 98,cent2144,maz
 99,chiq1250,maq
 100,sanm1295,mig


### PR DESCRIPTION
Fixed wrong Otomi variety in mapping file from Mezquital -> Tenango. Changed glottocode and ISOcode, regenerated phoible.csv with new change

Reported by Sandra Auderset:

> The language given for the Otomi SPA 97 inventory is Mezquital Otomí, but the source for the inventory is Blight & Pike 1976. This paper is on Tenango Otomí (otn, tena1241), not Mezquital (ote, mezq1235). This should be corrected, as the two varieties belong to different subgroups within Otomi.


Closes #385 

xref:
https://github.com/cldf-datasets/phoible/issues/43#issue-3754040974