### PR TITLE
Changed ISOCode of Darkhat khk to drh

### DIFF
--- a/mappings/InventoryID-LanguageCodes.csv
+++ b/mappings/InventoryID-LanguageCodes.csv
@@ -2254,7 +2254,7 @@ InventoryID,Glottocode,ISO6393
 2253,dupa1235,duo
 2254,lazz1240,lzz
 2255,dolg1241,dlg
-2256,dark1243,khk
+2256,dark1243,drh
 2257,jiar1240,jya
 2258,juan1238,jun
 2259,sout2697,azb


### PR DESCRIPTION
Changed ISOCode for Darkhat (dark1243) to drh, based on glottolog: https://glottolog.org/resource/languoid/id/dark1243

Closes #371
