### PR TITLE
Fix/awngi canonicalize

### DIFF
--- a/mappings/InventoryID-LanguageCodes.csv
+++ b/mappings/InventoryID-LanguageCodes.csv
@@ -126,7 +126,7 @@ InventoryID,Glottocode,ISO6393,LanguageName,SpecificDialect
 125,ngas1240,anc,Angas,NA
 126,marg1265,mrt,Margi,NA
 127,soma1255,som,Somali,NA
-128,awng1244,awn,Awiya,NA
+128,awng1244,awn,Awngi,NA
 129,iraq1241,irk,Iraqw,NA
 130,tigr1270,tig,Tigre,NA
 131,amha1245,amh,Amharic,NA
@@ -232,7 +232,7 @@ InventoryID,Glottocode,ISO6393,LanguageName,SpecificDialect
 231,egyp1253,arz,ARABIC,NA
 232,waor1240,auc,AUCA,NA
 233,avar1256,ava,AVAR,NA
-234,awng1244,awn,AWIYA,NA
+234,awng1244,awn,AWNGI,NA
 235,abip1241,axb,ABIPON,NA
 236,nort2697,azj,AZERBAIJANI,NA
 237,bash1264,bak,BASHKIR,NA


### PR DESCRIPTION
Changed inappropriate ethnonym for awng1244 (https://glottolog.org/resource/languoid/id/awng1244)

from Awiya -> Awngi

Reported in https://github.com/bambooforest/phoible-scripts/blob/master/ethiopia/get_ethiopia_languages.md

As per new columns, SourceLanguageName still contains Awiya. Is this still okay, as it won't be exposed in the CLDF but helps map to source?

Closes #305