### PR TITLE
Changed LanguageName: Lebanese Arabic to Libyan Arabic

### DIFF
--- a/mappings/InventoryID-LanguageCodes.csv
+++ b/mappings/InventoryID-LanguageCodes.csv
@@ -1096,7 +1096,7 @@ InventoryID,Glottocode,ISO6393,LanguageName,SpecificDialect
 1095,akla1241,akl,Aklan,NA
 1096,arhu1242,arh,Ika,NA
 1097,karo1306,arr,Karo,NA
-1098,liby1240,ayl,Lebanese Arabic,NA
+1098,liby1240,ayl,Libyan Arabic,NA
 1099,bata1289,bbc,Toba-Batak,NA
 1100,baou1238,bci,Baule,Kobe
 1101,bond1245,bfw,Remo,NA


### PR DESCRIPTION
Changed Language Name for 
https://glottolog.org/resource/languoid/id/liby1240

to Libyan Arabic

Closes  #376
