### PR TITLE
New contextual diacritic features

### DIFF
--- a/scripts/add-features.R
+++ b/scripts/add-features.R
@@ -411,7 +411,7 @@ handle_contextual_diacritics <- function(vec, base_glyph, is_click=FALSE) {
         else if (base_glyph %in% c("ʊ", "ɑ")) {
             vec$back <- "0"
         }
-        else if (base_glyph %in% c("i", "e")) {
+        else if (base_glyph %in% c("i", "e", "ø")) {
             vec$front <- "0"
             vec$tense <- "0"
         }

--- a/scripts/add-features.R
+++ b/scripts/add-features.R
@@ -330,7 +330,7 @@ handle_contextual_diacritics <- function(vec, base_glyph, is_click=FALSE) {
             # between mid-open and open
             vec$low <- "0"
         }
-        else if (base_glyph %in% c("æ", "a")) {
+        else if (base_glyph %in% c("æ", "a", "ɑ")) {
             # assigning +low is vacuous; little else makes sense ???
             vec$low <- "+"
         }

--- a/scripts/add-features.R
+++ b/scripts/add-features.R
@@ -260,7 +260,7 @@ handle_contextual_diacritics <- function(vec, base_glyph, is_click=FALSE) {
     create_glyph_type_variables(envir=environment())
     # uptack
     if (vec$GlyphID %in% "031D") {
-        if (base_glyph %in% c("ɹ", "r")) {
+        if (base_glyph %in% c("ɹ", "r", "ʟ")) {
             # make it fricative-like, but not strident
             vec$delayedRelease <- "+"
         }


### PR DESCRIPTION
Added the following phonemes into the contextual diacritic feature

ø̈ = ø + 0308 (Centralized), added with "i", "e" - Present in [Bashkir](https://eurphon.info/languages/html?lang_id=390)
         `vec$front <- "0"`
          `vec$tense <- "0"`


ɑ̞ = ɑ + 031E (Downtack), added with "æ", "a" - Present in [Mara (Lakher)](https://eurphon.info/languages/html?lang_id=12)

Near-open back unrounded vowel = Open back unrounded vowel + downtack

`vec$low <- "+"`

ʟ̝ = ʟ + 031D (Uptack), added "ɹ", "r" - Present in [Archi](https://eurphon.info/languages/html?lang_id=493)

Voiced velar lateral fricative = voiced velar lateral approximant + uptack

`vec$delayedRelease <- "+"` - make it fricative like

These are present in the new data that has not been added yet, so does not change current phoible.csv

@drammock Will need your feedback on these before merge

