### PR TITLE
Fix/mada wrong lang

### DIFF
--- a/mappings/InventoryID-LanguageCodes.csv
+++ b/mappings/InventoryID-LanguageCodes.csv
@@ -929,7 +929,7 @@ InventoryID,Glottocode,ISO6393,LanguageName,SpecificDialect
 928,luch1239,lch,Lucazi,NA
 929,orok1266,bdu,Lukundu,NA
 930,mace1250,mkd,Macedonian,NA
-931,mada1293,mxu,Mada,Rija
+931,mada1282,mda,Mada,Rija
 932,madi1260,mhi,Ma'di,NA
 933,mana1295,mva,Manam,NA
 934,bame1260,bce,Mamenyan,NA


### PR DESCRIPTION
> It seems that the inventory given for the Chadic language Mada (Cameroon) [https://phoible.org/languages/mada1293] is actually the inventory of the Plateau language Mada (Nigeria) [https://phoible.org/languages/mada1282]

Verified from the source https://www.academia.edu/3764840/Mada_dictionary_and_grammar_outline, this seems to be for the Plateau language Mada of Central Nigeria. 
Changed the glottocode, ISOcode and regenerated phoible.csv

Closes #409 
